### PR TITLE
Fixes #5: allow infinite retries on any implementation.

### DIFF
--- a/src/ExponentialBackOffStrategy.php
+++ b/src/ExponentialBackOffStrategy.php
@@ -45,7 +45,7 @@ class ExponentialBackOffStrategy implements BackOffStrategy
      */
     public function backOff(int $tries, Throwable $throwable): void
     {
-        if ($tries > $this->maxTries) {
+        if ($this->maxTries !== -1 && $tries > $this->maxTries) {
             throw $throwable;
         }
 

--- a/src/ExponentialBackOffStrategyTest.php
+++ b/src/ExponentialBackOffStrategyTest.php
@@ -7,6 +7,7 @@ use EventSauce\BackOff\Jitter\NoJitter;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use const PHP_INT_MAX;
 
 class ExponentialBackOffStrategyTest extends TestCase
 {
@@ -133,5 +134,18 @@ class ExponentialBackOffStrategyTest extends TestCase
             [2, 2.5, 250],
             [3, 2.5, 625],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_throw_an_exception_when_max_tries_is_infinite(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $backoff = new ExponentialBackOffStrategy(0, -1);
+        $exception = new RuntimeException('oops');
+
+        $backoff->backOff(PHP_INT_MAX, $exception);
     }
 }

--- a/src/FibonacciBackOffStrategy.php
+++ b/src/FibonacciBackOffStrategy.php
@@ -38,7 +38,7 @@ class FibonacciBackOffStrategy implements BackOffStrategy
 
     public function backOff(int $tries, Throwable $throwable): void
     {
-        if ($tries > $this->maxTries) {
+        if ($this->maxTries !== -1 && $tries > $this->maxTries) {
             throw $throwable;
         }
 

--- a/src/FibonacciBackOffStrategyTest.php
+++ b/src/FibonacciBackOffStrategyTest.php
@@ -7,6 +7,7 @@ use EventSauce\BackOff\Jitter\NoJitter;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use const PHP_INT_MAX;
 
 class FibonacciBackOffStrategyTest extends TestCase
 {
@@ -60,5 +61,18 @@ class FibonacciBackOffStrategyTest extends TestCase
         self::expectExceptionObject($exception);
 
         $backOff->backOff(26, $exception);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_throw_an_exception_when_max_tries_is_infinite(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $backoff = new FibonacciBackOffStrategy(0, -1);
+        $exception = new RuntimeException('oops');
+
+        $backoff->backOff(PHP_INT_MAX, $exception);
     }
 }

--- a/src/LinearBackOffStrategy.php
+++ b/src/LinearBackOffStrategy.php
@@ -40,7 +40,7 @@ class LinearBackOffStrategy implements BackOffStrategy
      */
     public function backOff(int $tries, Throwable $throwable): void
     {
-        if ($tries > $this->maxTries) {
+        if ($this->maxTries !== -1 && $tries > $this->maxTries) {
             throw $throwable;
         }
 

--- a/src/LinearBackOffStrategyTest.php
+++ b/src/LinearBackOffStrategyTest.php
@@ -6,6 +6,7 @@ use Closure;
 use EventSauce\BackOff\Jitter\NoJitter;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use const PHP_INT_MAX;
 
 class LinearBackOffStrategyTest extends TestCase
 {
@@ -95,6 +96,21 @@ class LinearBackOffStrategyTest extends TestCase
             [100, 101],
             [100, 150],
         ];
+    }
+
+
+
+    /**
+     * @test
+     */
+    public function it_does_not_throw_an_exception_when_max_tries_is_infinite(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $backoff = new LinearBackOffStrategy(0, -1);
+        $exception = new RuntimeException('oops');
+
+        $backoff->backOff(PHP_INT_MAX, $exception);
     }
 
     /**


### PR DESCRIPTION
Previously only available on the `NoWaitingBackOffStrategy`, now available for all strategies.