### PR TITLE
Fix overflow error (exponential backoff)

### DIFF
--- a/src/ExponentialBackOffStrategy.php
+++ b/src/ExponentialBackOffStrategy.php
@@ -50,6 +50,9 @@ class ExponentialBackOffStrategy implements BackOffStrategy
         }
 
         $delay = (int) ($this->initialDelayMs * $this->base ** ($tries - 1));
+        if($delay < 0){
+            $delay = $this->maxDelay;
+        }
         $delay = min($this->maxDelay, $delay);
         $delay = $this->jitter->jitter($delay);
 

--- a/src/ExponentialBackOffStrategyTest.php
+++ b/src/ExponentialBackOffStrategyTest.php
@@ -148,4 +148,11 @@ class ExponentialBackOffStrategyTest extends TestCase
 
         $backoff->backOff(PHP_INT_MAX, $exception);
     }
+
+    /** @test */
+    public function it_does_not_throw_exception_when_sleep_time_overflows_and_instead_respects_the_max_sleep_time()
+    {
+        $backoff = new ExponentialBackOffStrategy(50, 10000, 5000);
+        $backoff->backOff(60, new RuntimeException('oops'));
+    }
 }

--- a/src/ExponentialBackOffStrategyTest.php
+++ b/src/ExponentialBackOffStrategyTest.php
@@ -152,7 +152,9 @@ class ExponentialBackOffStrategyTest extends TestCase
     /** @test */
     public function it_does_not_throw_exception_when_sleep_time_overflows_and_instead_respects_the_max_sleep_time()
     {
-        $backoff = new ExponentialBackOffStrategy(50, 10000, 5000);
+        $backoff = new ExponentialBackOffStrategy(50, 10000, 5000, 2.0, $this->sleeper);
         $backoff->backOff(60, new RuntimeException('oops'));
+
+        self::assertEquals(5000, $this->recordedSleep);
     }
 }


### PR DESCRIPTION
This one has bitten me a few times, the exponential strategy can overflow sometimes, causing to ignore the maxDelay value since the overflow will be negative.